### PR TITLE
fix stub generation on Cursive

### DIFF
--- a/dev/server/user.clj
+++ b/dev/server/user.clj
@@ -9,18 +9,19 @@
     [template.system :as sys]))
 
 ;;FIGWHEEL
-(def figwheel-config (fig/fetch-config))
 (def figwheel (atom nil))
 
 ; Usable from a REPL to start one-or-more figwheel builds
 (defn start-figwheel
   "Start Figwheel on the given builds, or defaults to build-ids in `figwheel-config`."
   ([]
-   (let [props (System/getProperties)
+   (let [figwheel-config (fig/fetch-config)
+         props (System/getProperties)
          all-builds (->> figwheel-config :data :all-builds (mapv :id))]
      (start-figwheel (keys (select-keys props all-builds)))))
   ([build-ids]
-   (let [default-build-ids (-> figwheel-config :data :build-ids)
+   (let [figwheel-config (fig/fetch-config)
+         default-build-ids (-> figwheel-config :data :build-ids)
          build-ids (if (empty? build-ids) default-build-ids build-ids)
          preferred-config (assoc-in figwheel-config [:data :build-ids] build-ids)]
      (reset! figwheel (component/system-map


### PR DESCRIPTION
Deferring the config fetch prevents Fighwheel on trying to validate the configuration.